### PR TITLE
Configure the proxy from environment variables

### DIFF
--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -51,6 +51,7 @@ func NewRequestExecutor(httpClient *http.Client, cache cache.Cache, config *Conf
 
 	if httpClient == nil {
 		tr := &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			IdleConnTimeout: 30 * time.Second,
 		}
 		re.httpClient = &http.Client{Transport: tr}


### PR DESCRIPTION
This appears to be all that is required to get the Okta client to use the standard HTTP proxy environment variables, however it bypasses all of the other proxy configuration, although I'm not sure that is actually used anywhere anyway.